### PR TITLE
Add define()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,3 +21,4 @@ jobs:
         with:
           files: ./coverage/coverage-final.json
           fail_ci_if_error: true
+          token: 99895855-2d81-45cb-888b-c1992fa62adf

--- a/src/input_builder_factory.js
+++ b/src/input_builder_factory.js
@@ -53,5 +53,19 @@ export default function() {
         return this.makeFromCallback(name, inputCallback);
     }
 
-    return { register, defaults, getInputWith, makeFromCallback, make };
+    function define(inputCallback) {
+        const inputs = {};
+
+        inputCallback((name, builderCallback) => {
+            const input = this.make(name);
+            if (builderCallback) {
+                builderCallback(input);
+            }
+            return inputs[name] = input.get();
+        });
+
+        return inputs;
+    }
+
+    return { register, defaults, getInputWith, makeFromCallback, make, define };
 }

--- a/src/input_builder_factory.js
+++ b/src/input_builder_factory.js
@@ -58,7 +58,7 @@ export default function() {
 
         inputCallback((name, builderCallback) => {
             const input = this.make(name);
-            if (builderCallback) {
+            if(builderCallback) {
                 builderCallback(input);
             }
             return inputs[name] = input.get();

--- a/test/input_builder_factory.test.js
+++ b/test/input_builder_factory.test.js
@@ -1,6 +1,6 @@
-import { AeActionsError } from '../src/error.js';
+import { AeActionsError, InvalidInputsError } from '../src/error.js';
 import createFactory from '../src/input_builder_factory.js';
-import { result } from '../src/result.js';
+import { invalid, result, valid } from '../src/result.js';
 
 describe('input_builder_factory.js', () => {
     test('basic custom registration', () => {
@@ -27,6 +27,57 @@ describe('input_builder_factory.js', () => {
 
             expect(f).toThrow(AeActionsError);
             expect(f).toThrow('A getInputWith callback is required in order to instantiate an input builder!');
+        });
+    });
+
+    describe('define()', () => {
+        test('with valid inputs', () => {
+            const factory = createFactory()
+                .defaults()
+                .getInputWith((name) => name === 'boolean' ? 'true' : name + '!');
+
+            let innerRequired = undefined;
+            let innerOptional = undefined;
+            let innerBoolean = undefined;
+
+            const inputs = factory.define((input) => {
+                innerRequired = input('required', b => b.required());
+                innerOptional = input('optional');
+                innerBoolean = input('boolean', b => b.boolean());
+            });
+
+            expect(innerRequired).toBe('required!');
+            expect(innerOptional).toBe('optional!');
+            expect(innerBoolean).toBe(true);
+
+            expect(inputs).toStrictEqual({
+                required: 'required!',
+                optional: 'optional!',
+                boolean: true
+            });
+        });
+
+        test('with invalid inputs', () => {
+            const success = (b) => b.use(() => valid());
+            const fail = (b) => b.use(() => invalid());
+
+            const factory = createFactory()
+                .register('success', success)
+                .register('fail', fail)
+                .getInputWith(() => 'test'); 
+
+            let innerOk = undefined;
+            let innerLast = undefined;
+
+            const f = () => factory.define((input) => {
+                innerOk = input('ok', b => b.success());
+                input('bad', b => b.fail());
+                innerLast = input('never');
+            });
+
+            expect(f).toThrow(InvalidInputsError);
+            expect(innerOk).toBe('test');
+            expect(innerLast).toBe(undefined);
         });
     });
 });


### PR DESCRIPTION
Add a define() method to input builder factory as an easy DSL for input
definition.
